### PR TITLE
Remove empty id from cloned slide in infinite slider

### DIFF
--- a/slick/slick.js
+++ b/slick/slick.js
@@ -2464,18 +2464,18 @@
                 for (i = _.slideCount; i > (_.slideCount -
                         infiniteCount); i -= 1) {
                     slideIndex = i - 1;
-                    $(_.$slides[slideIndex]).clone(true).attr('id', '')
+                    $(_.$slides[slideIndex]).clone(true).attr('id', null)
                         .attr('data-slick-index', slideIndex - _.slideCount)
                         .prependTo(_.$slideTrack).addClass('slick-cloned');
                 }
                 for (i = 0; i < infiniteCount  + _.slideCount; i += 1) {
                     slideIndex = i;
-                    $(_.$slides[slideIndex]).clone(true).attr('id', '')
+                    $(_.$slides[slideIndex]).clone(true).attr('id', null)
                         .attr('data-slick-index', slideIndex + _.slideCount)
                         .appendTo(_.$slideTrack).addClass('slick-cloned');
                 }
                 _.$slideTrack.find('.slick-cloned').find('[id]').each(function() {
-                    $(this).attr('id', '');
+                    $(this).attr('id', null);
                 });
 
             }


### PR DESCRIPTION
This avoid html validation errors like:

```
"file:/homepage.html":309.31-309.151: error: Duplicate ID “”.
"file:/homepage.html":269.331-269.452: info warning: The first occurrence of ID “” was here.
"file:/homepage.html":309.31-309.151: error: Bad value “” for attribute “id” on element “div”: An ID must not be the empty string.
```